### PR TITLE
Remove issue_number parameter from review generation

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -141,7 +141,6 @@ jobs:
             "${{ steps.resolve.outputs.check_file }}" \
             "${{ steps.resolve.outputs.bioccheck_file }}" \
             "${{ steps.resolve.outputs.coverage_file }}" \
-            "${{ steps.resolve.outputs.issue }}" \
             "automated_review.md" \
             "${{ env.REVIEW_MODEL }}"
 

--- a/README.md
+++ b/README.md
@@ -88,28 +88,39 @@ Trigger `auto-review.yml` manually from the
 
 **Method 4: Local Review
 
+**Option A: Complete workflow (recommended)**
+
+Use the wrapper script to run all checks and generate the review in one command:
+
 ```bash
-# Review a local package checkout and write to a file:
-./scripts/generate_local_review.sh ~/reviews/MyPackage 1234 MyPackage_review.md
+# Review a local package and write to a file:
+./scripts/generate_local_review.sh ~/reviews/MyPackage MyPackage_review.md
 
 # Review and print to stdout:
 ./scripts/generate_local_review.sh ~/reviews/MyPackage
+```
 
-# Call the R script directly (e.g., after running build/check separately):
+This script runs R CMD check, BiocCheck, test coverage, then calls `generate_review.R`
+with the results.
+
+**Option B: Review from existing check results**
+
+If you've already run checks separately, call the R script directly:
+
+```bash
 Rscript generate_review.R \
     /path/to/package \
     check_results.txt \
     bioccheck_results.txt \
     coverage.json \
-    1234 \
     output_review.md
 ```
 
-`1234` above is an **example GitHub issue number**. Replace it with the real
-issue ID when posting back to an issue, or omit it for purely local review use.
+This is useful when reusing check artifacts or integrating into custom workflows.
 
-**Dependencies for local use:** `rcmdcheck`, `BiocCheck`, `covr`, `jsonlite`
-(all optional except `rcmdcheck`).
+---
+
+**Dependencies:** `rcmdcheck` (required), `BiocCheck`, `covr`, `jsonlite` (optional).
 
 ---
 
@@ -118,9 +129,9 @@ issue ID when posting back to an issue, or omit it for purely local review use.
 ```
 packages/                  Human reviews (one .txt per package)
 responses/                 Author responses to review comments
-generate_review.R          Core review generation script
+generate_review.R          Core review generator (takes check artifacts as input)
 scripts/
-  generate_local_review.sh Local wrapper (runs checks + review)
+  generate_local_review.sh Wrapper script (runs checks, then calls generate_review.R)
 .github/
   bioc-review-guidelines.instructions.md   AI review assistant guidelines
   workflows/

--- a/generate_review.R
+++ b/generate_review.R
@@ -9,14 +9,13 @@
 # Usage:
 #   Rscript generate_review.R <package_dir> [check_results.txt] \
 #                             [bioccheck_results.txt] [coverage.json] \
-#                             [issue_number] [output_file] [model_name]
+#                             [output_file] [model_name]
 #
 # Arguments:
 #   package_dir           Path to the package source directory (required)
 #   check_results.txt     Path to R CMD check output file  (optional)
 #   bioccheck_results.txt Path to BiocCheck output file    (optional)
 #   coverage.json         Path to covr JSON output         (optional)
-#   issue_number          GitHub issue number, e.g. 1234   (optional)
 #   output_file           Where to write the review        (optional, stdout)
 #   model_name            Name of the AI model used        (optional)
 #                         Falls back to REVIEW_MODEL env var, then a default.
@@ -34,7 +33,7 @@ suppressPackageStartupMessages({
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 1 || !nzchar(args[[1]])) {
   cat("Usage: Rscript generate_review.R <package_dir> [check_results] ",
-      "[bioccheck_results] [coverage.json] [issue_number] [output_file]\n")
+      "[bioccheck_results] [coverage.json] [output_file] [model_name]\n")
   quit(status = 1)
 }
 
@@ -42,9 +41,8 @@ pkg_dir          <- normalizePath(args[[1]], mustWork = TRUE)
 check_file       <- if (length(args) >= 2 && nzchar(args[[2]])) args[[2]] else ""
 bioccheck_file   <- if (length(args) >= 3 && nzchar(args[[3]])) args[[3]] else ""
 coverage_file    <- if (length(args) >= 4 && nzchar(args[[4]])) args[[4]] else ""
-issue_number     <- if (length(args) >= 5 && nzchar(args[[5]])) args[[5]] else ""
-output_file      <- if (length(args) >= 6 && nzchar(args[[6]])) args[[6]] else ""
-model_name       <- if (length(args) >= 7 && nzchar(args[[7]])) args[[7]] else ""
+output_file      <- if (length(args) >= 5 && nzchar(args[[5]])) args[[5]] else ""
+model_name       <- if (length(args) >= 6 && nzchar(args[[6]])) args[[6]] else ""
 # Fall back to environment variable, then a descriptive default
 if (!nzchar(model_name)) model_name <- Sys.getenv("REVIEW_MODEL", unset = "")
 if (!nzchar(model_name)) model_name <- "GitHub Copilot (automated reviewer)"
@@ -741,8 +739,6 @@ if (length(artifact_bullets) == 0) {
 # Assemble final review
 # ---------------------------------------------------------------------------
 
-issue_label <- if (nzchar(issue_number)) paste0(" #", issue_number) else ""
-
 repo_url <- "https://github.com/LiNk-NY/BiocReviews"
 readme_url <- paste0(repo_url, "#readme")
 review_date <- format(Sys.Date(), "%Y-%m-%d")
@@ -754,7 +750,7 @@ footer <- paste0(
 )
 
 sections <- paste(c(
-  paste0("# ", pkg_name, issue_label),
+  paste0("# ", pkg_name),
   "",
   render_section("DESCRIPTION", desc_bullets),
   render_section("NAMESPACE", ns_bullets),

--- a/scripts/generate_local_review.sh
+++ b/scripts/generate_local_review.sh
@@ -5,17 +5,15 @@
 # Runs R CMD check, BiocCheck, test coverage (optional), then generates review.
 #
 # Usage:
-#   ./scripts/generate_local_review.sh <package_dir> [issue_number] [output_file]
+#   ./scripts/generate_local_review.sh <package_dir> [output_file]
 #
 # Arguments:
 #   package_dir   Path to the R package source directory (required)
-#   issue_number  GitHub issue number (optional, default: "")
 #   output_file   Where to write the review (optional, default: stdout)
 #
 # Examples:
 #   ./scripts/generate_local_review.sh ~/reviews/MyPackage
-#   ./scripts/generate_local_review.sh ~/reviews/MyPackage 1234
-#   ./scripts/generate_local_review.sh ~/reviews/MyPackage 1234 MyPackage_review.md
+#   ./scripts/generate_local_review.sh ~/reviews/MyPackage MyPackage_review.md
 
 set -euo pipefail
 
@@ -23,13 +21,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/../generate_review.R"
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <package_dir> [issue_number] [output_file]" >&2
+  echo "Usage: $0 <package_dir> [output_file]" >&2
   exit 1
 fi
 
 PKG_DIR="$(realpath "$1")"
-ISSUE="${2:-}"
-OUTPUT="${3:-}"
+OUTPUT="${2:-}"
 
 if [[ ! -d "$PKG_DIR" ]]; then
   echo "Error: package directory not found: $PKG_DIR" >&2
@@ -144,7 +141,6 @@ RSCRIPT_ARGS=(
   "$CHECK_FILE"
   "$BIOCCHECK_FILE"
   "$COVERAGE_FILE"
-  "$ISSUE"
   "$OUTPUT"
 )
 


### PR DESCRIPTION
## Summary

Removes the `issue_number` parameter from `generate_review.R` and related scripts. This parameter only added `#1234` to the review heading, which provided no real value:

- **When posted to GitHub**: the issue context is already obvious from the comment location
- **When used locally**: the issue number is not relevant

## Changes

- **generate_review.R**: Removed `issue_number` parameter, review headings are now simply `# PackageName` instead of `# PackageName #1234`
- **generate_local_review.sh**: Removed `issue_number` from wrapper script call signature
- **auto-review.yml**: Updated workflow to not pass `issue_number` to R script
- **README.md**: Updated all examples and removed explanatory documentation about the parameter

## Notes

- The workflows still track issue numbers internally to determine where to post review comments
- This simplifies the interface by removing one unnecessary parameter
- No functional changes to the review content itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)