### PR TITLE
Fix BiocCheck output capture by copying log file

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -183,22 +183,15 @@ jobs:
       - name: Run BiocCheck
         continue-on-error: true
         run: |
-          result <- tryCatch({
-            out <- capture.output(
-              BiocCheck::BiocCheck("package", `quit-with-status` = FALSE, `no-check-bioc-help` = TRUE),
-              type = c("output", "message")
-            )
-            if (length(out) == 0 || all(nchar(trimws(out)) == 0)) {
-              out <- "BiocCheck completed but produced no console output. See workflow logs for details."
-            }
-            writeLines(out, "bioccheck_results.txt")
-            message("BiocCheck completed and results written to bioccheck_results.txt")
-          }, error = function(e) {
-            err_msg <- paste0("BiocCheck failed: ", conditionMessage(e))
-            message(err_msg)
-            writeLines(err_msg, "bioccheck_results.txt")
-          })
-        shell: Rscript {0}
+          Rscript -e "BiocCheck::BiocCheck('package', \`quit-with-status\` = FALSE, \`no-check-bioc-help\` = TRUE)" || true
+
+          # Copy BiocCheck log file to artifact location
+          bioccheck_log=$(find . -name "*.BiocCheck" -type d | head -1)/00BiocCheck.log
+          if [ -f "$bioccheck_log" ]; then
+            cp "$bioccheck_log" bioccheck_results.txt
+          else
+            echo "BiocCheck log file not found. Check workflow logs for details." > bioccheck_results.txt
+          fi
 
       - name: Upload build-check results artifact
         if: always()


### PR DESCRIPTION
## Problem

BiocCheck was producing output (visible in workflow logs), but the output wasn't being captured to `bioccheck_results.txt`. Instead, the artifact and issue comments showed:

```
BiocCheck completed but produced no console output. See workflow logs for details.
```

Example: [Issue #17](https://github.com/LiNk-NY/BiocReviews/issues/17)

## Root Cause

The previous approach used `capture.output()` which can't capture BiocCheck's direct console writes.

## Solution

BiocCheck natively creates a log file at `*.BiocCheck/00BiocCheck.log`. This PR simply copies that log file to `bioccheck_results.txt` instead of trying to capture console output.

Benefits:
- **Simplest approach**: Uses BiocCheck's native log file output
- **Most reliable**: Always gets the complete, properly formatted log  
- **No complexity**: No output redirection or sink manipulation needed
- **Natural error handling**: File won't exist if BiocCheck fails, handled with fallback message

## Result

BiocCheck results will now be properly captured in artifacts and displayed in issue comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)