### PR TITLE
Fix LLM review fallback and add package name to workflow title

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -203,14 +203,33 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const reviewPath = '${{ steps.llm.outputs.review_file }}' || 'automated_review.md';
+            const reviewPath = '${{ steps.llm.outputs.review_file }}' || 'automated_review_llm.md';
             const wasTruncated = '${{ steps.llm.outputs.truncated }}' === 'true';
             const statusLine = wasTruncated
               ? '> ⚠️ Input context was truncated before LLM generation. See the review header for details.\n\n'
               : '';
-            const review = fs.existsSync(reviewPath)
-              ? fs.readFileSync(reviewPath, 'utf8')
-              : '_Review generation failed — check workflow logs._';
+
+            let review = '_Review generation failed — check workflow logs._';
+
+            // Try to read the LLM-enhanced review first
+            if (fs.existsSync(reviewPath)) {
+              const content = fs.readFileSync(reviewPath, 'utf8').trim();
+              // Check if the content is meaningful (more than just the header)
+              // A valid review should be longer than just a header line
+              if (content.length > 150) {
+                review = content;
+              } else {
+                core.warning('LLM-enhanced review is too short, falling back to base review');
+                // Fall back to base review if LLM version is too short
+                if (fs.existsSync('automated_review.md')) {
+                  review = fs.readFileSync('automated_review.md', 'utf8');
+                }
+              }
+            } else if (fs.existsSync('automated_review.md')) {
+              // Fall back to base review if LLM version doesn't exist
+              core.warning('LLM-enhanced review not found, using base review');
+              review = fs.readFileSync('automated_review.md', 'utf8');
+            }
 
             await github.rest.issues.createComment({
               issue_number: Number('${{ steps.resolve.outputs.issue }}'),

--- a/scripts/enhance_review_with_github_models.R
+++ b/scripts/enhance_review_with_github_models.R
@@ -117,21 +117,42 @@ tryCatch({
     api_url
   )
 
+  message("Calling GitHub Models API with model: ", model)
   response_lines <- system(curl_cmd, intern = TRUE)
   status <- attr(response_lines, "status")
   if (!is.null(status) && status != 0) {
     stop(sprintf("curl exited with status %s", status))
   }
 
-  body <- fromJSON(paste(response_lines, collapse = "\n"), simplifyVector = FALSE)
+  response_text <- paste(response_lines, collapse = "\n")
+  message("API response length: ", nchar(response_text), " characters")
+
+  body <- fromJSON(response_text, simplifyVector = FALSE)
+
+  # Check if response has expected structure
+  if (is.null(body$choices) || length(body$choices) == 0) {
+    stop(sprintf("API response missing choices. Response keys: %s",
+                 paste(names(body), collapse = ", ")))
+  }
+
   content <- body$choices[[1]]$message$content
+  if (is.null(content) || !nzchar(as.character(content))) {
+    stop("API response content is empty or null")
+  }
+
   llm_text <- extract_content(content)
+  message("Extracted LLM text length: ", nchar(llm_text), " characters")
+
+  if (!nzchar(llm_text)) {
+    stop("Extracted content is empty after processing")
+  }
 }, error = function(e) {
+  message("ERROR: ", conditionMessage(e))
   llm_status <<- "fallback"
   llm_text <<- paste0(
     "## LLM enhancement unavailable\n",
     "- Attempted model: `", model, "`\n",
-    "- Error: `", class(e)[1], "`\n\n",
+    "- Error: `", conditionMessage(e), "`\n\n",
     "The rule-based review is provided below.\n\n",
     base_review
   )


### PR DESCRIPTION
## Summary
- Fixes blank review posts when GitHub Models API fails or returns empty content
- Improves error handling and diagnostics in LLM enhancement script

## Changes

### Workflow improvements ([.github/workflows/auto-review.yml](.github/workflows/auto-review.yml))
- Added `run-name` to display package identifier in workflow runs list
- Implemented fallback logic to use base review when LLM-enhanced version is empty or too short
- Added warning logs when falling back to base review

### Script improvements ([scripts/enhance_review_with_github_models.R](scripts/enhance_review_with_github_models.R))
- Added diagnostic logging to track API calls and response processing
- Validates API response structure before processing
- Checks for empty/null content at multiple stages
- Includes actual error messages in fallback output

## Fixes
Addresses the issue reported in #17 where a nearly blank review was posted due to API failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)