### PR TITLE
Fix: model parameter not passed to auto-review workflow

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -245,6 +245,7 @@ jobs:
             issue_number.txt
             target_repo.txt
             target_ref.txt
+            llm_model.txt
           retention-days: 7
 
       - name: Post build/check summary to issue


### PR DESCRIPTION
## Problem

When users specified a model via `@biocreview gemini-3.1-pro-preview`, the workflow always used `gpt-4o` instead.

## Root Cause

The `build-check.yml` workflow:
1. ✅ Parsed the model from the comment correctly
2. ✅ Wrote it to `llm_model.txt`
3. ❌ **Did not include `llm_model.txt` in the metadata artifact**

The `auto-review.yml` workflow tried to read `build_meta/llm_model.txt` from the artifact, found it missing, and fell back to the default `gpt-4o`.

## Solution

Added `llm_model.txt` to the `build-check-metadata` artifact upload path list.

## Testing

After this fix, triggering a review with `@biocreview gemini-3.1-pro-preview` will correctly:
1. Parse `gemini-3.1-pro-preview` from the comment
2. Write it to `llm_model.txt`
3. Upload it in the metadata artifact
4. Auto-review workflow reads it and uses the correct model

Fixes #14