### PR TITLE
List available models when model not found

### DIFF
--- a/scripts/enhance_review_with_llm.R
+++ b/scripts/enhance_review_with_llm.R
@@ -36,6 +36,53 @@ extract_content <- function(content) {
   as.character(content)
 }
 
+list_available_models <- function(provider, token) {
+  tryCatch({
+    if (provider == "gemini") {
+      list_url <- sprintf("https://generativelanguage.googleapis.com/v1beta/models?key=%s", token)
+      curl_cmd <- sprintf("curl -sS '%s'", list_url)
+    } else {
+      # GitHub Models list endpoint
+      list_url <- "https://models.inference.ai.azure.com/models"
+      curl_cmd <- sprintf("curl -sS -H 'Authorization: Bearer %s' '%s'", token, list_url)
+    }
+
+    response_lines <- system(curl_cmd, intern = TRUE)
+    if (is.null(attr(response_lines, "status")) || attr(response_lines, "status") == 0) {
+      response_text <- paste(response_lines, collapse = "\n")
+      body <- fromJSON(response_text, simplifyVector = FALSE)
+
+      if (provider == "gemini") {
+        # Extract model names from Gemini response
+        if (!is.null(body$models)) {
+          models <- vapply(body$models, function(m) {
+            # Extract just the model name from "models/gemini-xxx"
+            name <- sub("^models/", "", m$name)
+            # Filter to only generation models (exclude embedding, etc.)
+            if (!is.null(m$supportedGenerationMethods) &&
+                "generateContent" %in% unlist(m$supportedGenerationMethods)) {
+              name
+            } else {
+              NA_character_
+            }
+          }, character(1))
+          models <- models[!is.na(models)]
+          return(sort(models))
+        }
+      } else {
+        # Parse GitHub Models response
+        if (!is.null(body$data)) {
+          models <- vapply(body$data, function(m) m$id, character(1))
+          return(sort(models))
+        }
+      }
+    }
+    character(0)
+  }, error = function(e) {
+    character(0)
+  })
+}
+
 base_review_path <- get_arg("--base-review", required = TRUE)
 output_path <- get_arg("--output", required = TRUE)
 check_file <- get_arg("--check-file", default = "")
@@ -229,13 +276,41 @@ tryCatch({
 }, error = function(e) {
   message("ERROR: ", conditionMessage(e))
   llm_status <<- "fallback"
-  llm_text <<- paste0(
+
+  error_msg <- conditionMessage(e)
+  fallback_parts <- c(
     "## LLM enhancement unavailable\n",
-    "- Attempted model: `", model, "`\n",
-    "- Error: `", conditionMessage(e), "`\n\n",
-    "The rule-based review is provided below.\n\n",
+    sprintf("- Attempted model: `%s`\n", model),
+    sprintf("- Error: `%s`\n", error_msg)
+  )
+
+  # If the error suggests a model not found, list available models
+  if (grepl("not found|not supported|invalid model|model.*not.*available", error_msg, ignore.case = TRUE)) {
+    message("Fetching list of available models...")
+    available <- list_available_models(provider, token)
+    if (length(available) > 0) {
+      fallback_parts <- c(
+        fallback_parts,
+        "\n### Available models\n",
+        sprintf("Try one of these %s models instead:\n", if (provider == "gemini") "Gemini" else "GitHub"),
+        paste0("- `", available, "`", collapse = "\n"),
+        "\n"
+      )
+    } else {
+      fallback_parts <- c(
+        fallback_parts,
+        "\n(Could not fetch list of available models)\n"
+      )
+    }
+  }
+
+  fallback_parts <- c(
+    fallback_parts,
+    "\nThe rule-based review is provided below.\n\n",
     base_review
   )
+
+  llm_text <<- paste0(fallback_parts, collapse = "")
 })
 
 provider_name <- if (provider == "gemini") "Google Gemini" else "GitHub Models"


### PR DESCRIPTION
## Problem

When users specify an invalid or unsupported model (like `gemini-3.1-flash-lite` which doesn't exist in v1beta API), they get a generic error message without knowing which models are actually available.

## Solution

Added automatic model listing when model-related errors are detected:

1. **Detects model errors** - Checks if error message contains keywords like "not found", "not supported", "invalid model"
2. **Fetches available models** - Calls the provider's list models endpoint:
   - Gemini: `https://generativelanguage.googleapis.com/v1beta/models`
   - GitHub Models: `https://models.inference.ai.azure.com/models`
3. **Filters appropriately**:
   - Gemini: Only shows models that support `generateContent` method
   - GitHub Models: Shows all available model IDs
4. **Displays in error message** - Lists available models with usage examples

## Example Output

When `@biocreview gemini-3.1-flash-lite` fails, the review will now show:

```markdown
## LLM enhancement unavailable
- Attempted model: `gemini-3.1-flash-lite`
- Error: `models/gemini-3.1-flash-lite is not found for API version v1beta`

### Available models
Try one of these Gemini models instead:
- `gemini-1.5-flash`
- `gemini-1.5-flash-8b`
- `gemini-1.5-pro`
- `gemini-2.0-flash-exp`
...

The rule-based review is provided below.
```

## Benefits

- Users immediately see which models they can use
- No need to consult external documentation
- Works for both Gemini and GitHub Models
- Graceful fallback if model list fetch fails

Related to #14